### PR TITLE
Fix amazon css selector

### DIFF
--- a/deal_finder/utils/product_meta_collector.py
+++ b/deal_finder/utils/product_meta_collector.py
@@ -21,7 +21,7 @@ class ProductMetaCollector:
 
     @staticmethod
     def get_product_meta_from_amazon() -> ProductMeta:
-        price = ProductMetaCollector.__get_price(".priceToPay")
+        price = ProductMetaCollector.__get_price("#corePriceDisplay_desktop_feature_div .a-offscreen")
 
         product_availability_text = web_browser.get_element_text_by_css_selector("#availability > span")
         if not product_availability_text:


### PR DESCRIPTION
## Issue with previous selector

The element found by previous css selector had two child `span` elements, both containing the product price. One of them was hidden on webpage. But when we tried to get `textContent` from the element, the price was duplicated. For instance, if a product was priced at `₹250`. We received it as `₹250₹250`. After moving it to the transformer the final price turned out to be `250250` and the comparison against `price_threshold` wasn't correct anymore.